### PR TITLE
Add new operator keys and corresponding styles

### DIFF
--- a/src/common/components/KeyboardRender.js
+++ b/src/common/components/KeyboardRender.js
@@ -36,6 +36,12 @@ export default function () {
       </div>
 
       <div className='keyboard-row'>
+        <Key keyType='operator' keyValue='power' keySymbol='x²' />
+        <Key keyType='operator' keyValue='root' keySymbol='√' />
+        <Key keyType='operator' keyValue='modulus' keySymbol='%' />
+      </div>
+
+      <div className='keyboard-row'>
         <Key keyType='action' keyValue='back' keySymbol='<<' />
         <Key keyType='action' keyValue='equal' keySymbol='=' />
       </div>

--- a/src/common/stores/CalculatorStore.js
+++ b/src/common/stores/CalculatorStore.js
@@ -231,6 +231,22 @@ function processCalculation() {
         }
         _symbolKeyTyped = '÷';
         break;
+      case 'power':
+        calculation = Math.pow(_numbersFromBuffer[0], _numbersFromBuffer[1]);
+        _symbolKeyTyped = '^';
+        break;
+      case 'root':
+        calculation = Math.pow(_numbersFromBuffer[0], 1 / _numbersFromBuffer[1]);
+        _symbolKeyTyped = '√';
+        break;
+      case 'modulus':
+        if (_numbersFromBuffer[1] === 0) {
+          calculation = 'Error';
+        } else {
+          calculation = _numbersFromBuffer[0] % _numbersFromBuffer[1];
+        }
+        _symbolKeyTyped = '%';
+        break;
       default:
     }
     _lastCalculation = {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -104,6 +104,24 @@ html, body {
   padding-left: 13px;
   padding-right: 13px;
 }
+.operator.power {
+  background-color: #f8f8f8;
+  color: #919191;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.operator.root {
+  background-color: #f8f8f8;
+  color: #919191;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.operator.modulus {
+  background-color: #f8f8f8;
+  color: #919191;
+  padding-left: 12px;
+  padding-right: 12px;
+}
 
 .key-action {
   width: 50%;


### PR DESCRIPTION
This pull request primarily introduces new functionality to the calculator application. Three new operations - power, root, and modulus - have been added. These changes span across the keyboard rendering component, the calculation processing function, and the CSS styling for these new keys.

New functionality:

* [`src/common/components/KeyboardRender.js`](diffhunk://#diff-6006846eac3e32815860b5f923b66283a12e91494ab7c40aed586c9264742577R38-R43): Added a new row of keys to the keyboard for the power, root, and modulus operations.
* [`src/common/stores/CalculatorStore.js`](diffhunk://#diff-03d9bce51d5ce747b74cff9745471e85400d865c8618240527c43f1bd6e6c4c3R234-R249): Extended the `processCalculation` function to handle the new power, root, and modulus operations.

Styling:

* [`src/styles/main.css`](diffhunk://#diff-25d6a3ff17a1c8acb9b8e63e990597d94ef65730407b2e171edbf73b7515df3dR107-R124): Added specific styling for the new power, root, and modulus keys.