### PR TITLE
Add power, root, and modulus calculations to CalculatorStore.js

### DIFF
--- a/src/common/stores/CalculatorStore.js
+++ b/src/common/stores/CalculatorStore.js
@@ -231,6 +231,22 @@ function processCalculation() {
         }
         _symbolKeyTyped = '÷';
         break;
+      case 'power':
+        calculation = Math.pow(_numbersFromBuffer[0], _numbersFromBuffer[1]);
+        _symbolKeyTyped = '^';
+        break;
+      case 'root':
+        calculation = Math.pow(_numbersFromBuffer[0], 1 / _numbersFromBuffer[1]);
+        _symbolKeyTyped = '√';
+        break;
+      case 'modulus':
+        if (_numbersFromBuffer[1] === 0) {
+          calculation = 'Error';
+        } else {
+          calculation = _numbersFromBuffer[0] % _numbersFromBuffer[1];
+        }
+        _symbolKeyTyped = '%';
+        break;
       default:
     }
     _lastCalculation = {


### PR DESCRIPTION
This pull request primarily extends the functionality of the `processCalculation` function in the `CalculatorStore.js` file. The changes introduce three new mathematical operations: power, root, and modulus.

Here are the key changes:

* [`src/common/stores/CalculatorStore.js`](diffhunk://#diff-03d9bce51d5ce747b74cff9745471e85400d865c8618240527c43f1bd6e6c4c3R234-R249): The `processCalculation` function now supports the 'power' operation, which raises the first number in `_numbersFromBuffer` to the power of the second number.
* [`src/common/stores/CalculatorStore.js`](diffhunk://#diff-03d9bce51d5ce747b74cff9745471e85400d865c8618240527c43f1bd6e6c4c3R234-R249): The 'root' operation has been added to `processCalculation`. This operation calculates the root of the first number in `_numbersFromBuffer` based on the second number.
* [`src/common/stores/CalculatorStore.js`](diffhunk://#diff-03d9bce51d5ce747b74cff9745471e85400d865c8618240527c43f1bd6e6c4c3R234-R249): The 'modulus' operation has also been added to `processCalculation`. This operation calculates the remainder of the division of the first number in `_numbersFromBuffer` by the second number. If the second number is zero, it returns 'Error'.