### PR TITLE
Add power, root, and modulus calculations to CalculatorStore.js

### DIFF
--- a/src/common/stores/CalculatorStore.js
+++ b/src/common/stores/CalculatorStore.js
@@ -231,6 +231,22 @@ function processCalculation() {
         }
         _symbolKeyTyped = '÷';
         break;
+      case 'power':
+        calculation = Math.pow(_numbersFromBuffer[0], _numbersFromBuffer[1]);
+        _symbolKeyTyped = '^';
+        break;
+      case 'root':
+        calculation = Math.pow(_numbersFromBuffer[0], 1 / _numbersFromBuffer[1]);
+        _symbolKeyTyped = '√';
+        break;
+      case 'modulus':
+        if (_numbersFromBuffer[1] === 0) {
+          calculation = 'Error';
+        } else {
+          calculation = _numbersFromBuffer[0] % _numbersFromBuffer[1];
+        }
+        _symbolKeyTyped = '%';
+        break;
       default:
     }
     _lastCalculation = {


### PR DESCRIPTION
This pull request primarily introduces new mathematical operations to the `processCalculation` function in the `CalculatorStore.js` file. The new operations include power, root, and modulus, each with its corresponding symbol.

* [`src/common/stores/CalculatorStore.js`](diffhunk://#diff-03d9bce51d5ce747b74cff9745471e85400d865c8618240527c43f1bd6e6c4c3R234-R249): Added three new mathematical operations to the `processCalculation` function. The 'power' operation calculates the power of the first number to the second number and assigns '^' to `_symbolKeyTyped`. The 'root' operation calculates the root of the first number by the second number and assigns '√' to `_symbolKeyTyped`. The 'modulus' operation calculates the modulus of the first number by the second number and assigns '%' to `_symbolKeyTyped`. If the second number is zero in the 'modulus' operation, it sets the calculation to 'Error'.